### PR TITLE
📄 Added MIT License to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/w/shivamm-verma/daily-dsa)
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/w/shivamm-verma/daily-dsa)
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/t/shivamm-verma/daily-dsa)
+[![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 
 <!-- [![License: MPL 2.0](https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg)](https://opensource.org/licenses/MPL-2.0) -->
 </p>
@@ -62,3 +63,14 @@ Can you help in increasing these numbers below?😄📈
 
 ![GitHub forks](https://img.shields.io/github/stars/shivamm-verma/Daily-DSA?style=for-the-badge) ![GitHub forks](https://img.shields.io/github/forks/shivamm-verma/Daily-DSA?style=for-the-badge)
 
+## 📝 License
+
+<div align="center">
+
+<!-- Project License Statement -->
+<p>
+  This project is licensed under the terms of the <strong><a href="./LICENSE">MIT License</a></strong>.<br>
+  You are free to use, modify, and distribute this project with proper attribution.
+</p>
+
+</div>


### PR DESCRIPTION
🔄 Pull Request: Add MIT License Badge to README
📌 Issue Reference:
Closes #93

👤 Author:
@vinitjain2005 

📝 Summary:
This PR adds the MIT License badge to the README file, maintaining consistency with the existing badge formatting used in the project.

✅ Changes Made:
Added a clickable MIT License badge to the README.
Ensured the badge styling aligns with the other GitHub shields used in the project.

📚 Motivation:
Adding the license badge improves visibility of the project's licensing and reinforces its open-source nature for contributors and users.

📷 Screenshot 
<img width="1004" height="201" alt="Screenshot 2025-08-04 180218" src="https://github.com/user-attachments/assets/56d79369-0212-4d58-bf59-6b7856832520" />
<img width="1010" height="126" alt="Screenshot 2025-08-04 180230" src="https://github.com/user-attachments/assets/1dcdcfdf-8ec6-48b0-bdb7-b60db16268b2" />
